### PR TITLE
add highlight groups for separators of modified tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ TabLineSel
 TabLineFill
 TabLineSeparatorActive
 TabLineSeparatorInactive
+TabLineModifiedSeparatorActive
+TabLineModifiedSeparatorInactive
 TabLinePaddingActive
 TabLinePaddingInactive
 TabLineModifiedActive

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -23,7 +23,7 @@ local tabline = function()
 
         -- stylua: ignore
         local tabline_items = {
-            utils.get_item('TabLineSeparator', opt.separator, active),       -- Left separator
+            icons.get_left_separator(active, bufmodified),                   -- Left separator
             utils.get_item('TabLinePadding', padding, active),               -- Padding
             icons.get_devicon(active, filename, extension),                  -- DevIcon
             utils.get_item('TabLine', filename, active, true),               -- Filename

--- a/lua/tabline/highlights.lua
+++ b/lua/tabline/highlights.lua
@@ -42,18 +42,21 @@ M.c = {
     active_text = '#eeeeee',
     inactive_text = '#7f8490',
     active_sep = '#ff6077',
+    modified_active_sep = '#ff6077',
 }
 
 -- stylua: ignore
 M.highlight_all({
-    { 'TabLineSeparatorActive',   { guifg = M.c.active_sep,    guibg = M.c.active_bg } },
-    { 'TabLineSeparatorInactive', { guifg = M.c.inactive_text, guibg = M.c.inactive_bg } },
-    { 'TabLinePaddingActive',     { guifg = M.c.active_bg,     guibg = M.c.active_bg } },
-    { 'TabLinePaddingInactive',   { guifg = M.c.inactive_bg,   guibg = M.c.inactive_bg } },
-    { 'TabLineModifiedActive',    { guifg = M.c.active_text,   guibg = M.c.active_bg } },
-    { 'TabLineModifiedInactive',  { guifg = M.c.inactive_text, guibg = M.c.inactive_bg } },
-    { 'TabLineCloseActive',       { guifg = M.c.active_text,   guibg = M.c.active_bg } },
-    { 'TabLineCloseInactive',     { guifg = M.c.inactive_text, guibg = M.c.inactive_bg } },
+    { 'TabLineSeparatorActive',             { guifg = M.c.active_sep,           guibg = M.c.active_bg } },
+    { 'TabLineSeparatorInactive',           { guifg = M.c.inactive_text,        guibg = M.c.inactive_bg } },
+    { 'TabLineModifiedSeparatorActive',     { guifg = M.c.modified_active_sep,  guibg = M.c.active_bg } },
+    { 'TabLineModifiedSeparatorInactive',   { guifg = M.c.inactive_text,        guibg = M.c.inactive_bg } },
+    { 'TabLinePaddingActive',               { guifg = M.c.active_bg,            guibg = M.c.active_bg } },
+    { 'TabLinePaddingInactive',             { guifg = M.c.inactive_bg,          guibg = M.c.inactive_bg } },
+    { 'TabLineModifiedActive',              { guifg = M.c.active_text,          guibg = M.c.active_bg } },
+    { 'TabLineModifiedInactive',            { guifg = M.c.inactive_text,        guibg = M.c.inactive_bg } },
+    { 'TabLineCloseActive',                 { guifg = M.c.active_text,          guibg = M.c.active_bg } },
+    { 'TabLineCloseInactive',               { guifg = M.c.inactive_text,        guibg = M.c.inactive_bg } },
 })
 
 return M

--- a/lua/tabline/icons.lua
+++ b/lua/tabline/icons.lua
@@ -4,6 +4,13 @@ local config = require('tabline.config')
 local utils = require('tabline.utils')
 
 -- Return icon with fg color
+M.get_left_separator = function(active, modified)
+    if modified == 1 then
+        return utils.get_item('TabLineModifiedSeparator', config.get('separator'), active)
+    end
+    return utils.get_item('TabLineSeparator', config.get('separator'), active)
+end
+
 M.get_devicon = function(active, filename, extension)
     local ok, web = pcall(require, 'nvim-web-devicons')
     if ok then


### PR DESCRIPTION
Hello! I installed this plugin a few days ago and found it useful and elegant.

However, I felt that the modification icon was not clear enough to me, so I added the feature to tell whether a tab is modified by the separator's color.

Here is a short demo video.

https://user-images.githubusercontent.com/24734750/129467107-b112c7df-c5be-44de-8cc5-a07cce3bb271.mp4

