### PR TITLE
Remove right padding around around tab name

### DIFF
--- a/lua/tabline/utils.lua
+++ b/lua/tabline/utils.lua
@@ -25,9 +25,9 @@ M.get_tabname = function(bufname, index)
         return title
     end
     if bufname == '' then
-        return config.get('no_name') .. ' '
+        return config.get('no_name')
     end
-    return vim.fn.fnamemodify(bufname, ':t') .. ' '
+    return vim.fn.fnamemodify(bufname, ':t')
 end
 
 return M


### PR DESCRIPTION
Removed b/c it looks odd if the tabline bg is different than the
normal editor background as the padding is given the highlight of the
filename.