### PR TITLE
updating custom tab name instantly

### DIFF
--- a/lua/tabline/actions.lua
+++ b/lua/tabline/actions.lua
@@ -7,8 +7,8 @@ M.set_tabname = function()
         end
         local tabnr = vim.fn.tabpagenr()
         vim.fn.settabvar(tabnr, 'TablineTitle', input)
+        vim.cmd('redrawtabline')
     end)
-    vim.cmd('redrawtabline')
 end
 
 M.clear_tabname = function()


### PR DESCRIPTION
Calling `redrawtabline` within the callback ensures that the new tab name is instantly visible after submitting

The current call outside the callback is not doing anything. So after a rename the old tab name is still visible until Neovim decides to redraw the tabline by itself