### PR TITLE
Fix config.get() and highlight group.

### DIFF
--- a/lua/tabline/config.lua
+++ b/lua/tabline/config.lua
@@ -20,7 +20,10 @@ M.set = function(user_options)
 end
 
 M.get = function(key)
-    return key and config[key] or config
+    if key and config[key] ~= nil then
+        return config[key]
+    end
+    return config
 end
 
 return M

--- a/lua/tabline/highlights.lua
+++ b/lua/tabline/highlights.lua
@@ -6,29 +6,33 @@ M.get_color = function(group, attr)
 end
 
 M.c = {
-    active_bg = M.get_color('TabLineSel', 'bg'),
-    inactive_bg = M.get_color('TabLine', 'bg'),
     active_text = '#eeeeee',
     inactive_text = '#7f8490',
     active_sep = '#ff6077',
 }
 
+M.get_bg = function (active)
+    local group = active and 'TabLineSel' or 'TabLine'
+    return M.get_color(group, 'bg')
+end
+
 local hi = function(colors)
     for name, opts in pairs(colors) do
+        opts.default = true
         vim.api.nvim_set_hl(0, name, opts)
     end
 end
 
 -- stylua: ignore start
 hi({
-     TabLineSeparatorSel = { fg = M.c.active_sep,    bg = M.c.active_bg } ,
-     TabLineSeparator    = { fg = M.c.inactive_text, bg = M.c.inactive_bg } ,
-     TabLineModifiedSel  = { fg = M.c.active_text,   bg = M.c.active_bg } ,
-     TabLineModified     = { fg = M.c.inactive_text, bg = M.c.inactive_bg } ,
-     TabLineCloseSel     = { fg = M.c.active_text,   bg = M.c.active_bg } ,
-     TabLineClose        = { fg = M.c.inactive_text, bg = M.c.inactive_bg } ,
-     TabLinePaddingSel   = { link = 'TabLineSel' },
-     TabLinePadding      = { link = 'TabLine' },
+    TabLineSeparatorSel = { fg = M.c.active_sep,    bg = M.get_bg(true) } ,
+    TabLineSeparator    = { fg = M.c.inactive_text, bg = M.get_bg(false) } ,
+    TabLineModifiedSel  = { fg = M.c.active_text,   bg = M.get_bg(true) } ,
+    TabLineModified     = { fg = M.c.inactive_text, bg = M.get_bg(false) } ,
+    TabLineCloseSel     = { fg = M.c.active_text,   bg = M.get_bg(true) } ,
+    TabLineClose        = { fg = M.c.inactive_text, bg = M.get_bg(false) } ,
+    TabLinePaddingSel   = { link = 'TabLineSel' },
+    TabLinePadding      = { link = 'TabLine' },
 })
 -- stylua: ignore end
 

--- a/lua/tabline/icons.lua
+++ b/lua/tabline/icons.lua
@@ -16,13 +16,13 @@ M.get_devicon = function(index, bufname, extension)
         icon_hl = 'TabLine' .. icon_hl
 
         local active_color = hl.get_color('TabLineIconSel', 'fg') or color
-        vim.api.nvim_set_hl(0, icon_hl .. 'Sel', { fg = active_color, bg = hl.c.active_bg })
+        vim.api.nvim_set_hl(0, icon_hl .. 'Sel', { fg = active_color, bg = hl.get_bg(true) })
 
         local inactive_color = (not config.get('color_all_icons') and hl.c.inactive_text)
             or hl.get_color('TabLineIcon', 'fg')
             or color
 
-        vim.api.nvim_set_hl(0, icon_hl, { fg = inactive_color, bg = hl.c.inactive_bg })
+        vim.api.nvim_set_hl(0, icon_hl, { fg = inactive_color, bg = hl.get_bg(false) })
         return utils.get_item(icon_hl, icon, index)
     end
     return ''


### PR DESCRIPTION
Greetings,

Recently I have upgraded nvim-tabline, but I encountered some problems. First, even I set `right_separator` to false it still appeared. Second, I could not set the color of each highlight group by putting `vim.cmd('highlight ...')` in my config. It seemed like the default one just overwrote my settings. Luckily, these problems were later resolved. Hope you could take a look at my commits and check whether there's any missed mistakes.

Best Regards,
Alan