### PR TITLE
New feature : count windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ Plug 'nvim-tree/nvim-web-devicons'             " Optional
 call plug#end()
 ```
 
+### lazy.nvim
+
+```lua
+return {
+    "seblj/nvim-tabline",
+    dependencies = { "nvim-tree/nvim-web-devicons" }, -- Optional
+    opts = {
+        ... -- see options below
+    }
+}
+```
+
 ## Setup
 
 ```lua
@@ -42,6 +54,13 @@ require('tabline').setup({
     right_separator = false,  -- Show right separator on the last tab
     show_index = false,       -- Shows the index of tab before filename
     show_icon = true,         -- Shows the devicon
+    show_window_count = {
+        enable = false,                    -- Shows the number of windows in tab after filename  
+        show_if_alone = false,             -- do not show count if unique win in a tab
+        count_unique_buf = true,           -- count only win showing different buffers
+        count_others = true,               -- display [+x] where x is the number of other windows
+        buftype_blacklist = { 'nofile' },  -- do not count if buftype among theses
+    },
 })
 ```
 

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -8,7 +8,7 @@ local tabline = function()
     local last_index = vim.fn.tabpagenr('$')
 
     local s = ''
-    for index = 1, last_index do
+    for index, tabpage_handle in pairs(vim.api.nvim_list_tabpages()) do
         local winnr = vim.fn.tabpagewinnr(index)
         local bufnr = vim.fn.tabpagebuflist(index)[winnr]
         local bufname = vim.fn.bufname(bufnr)
@@ -16,6 +16,7 @@ local tabline = function()
         local tabname = utils.get_tabname(bufname, index)
         local extension = vim.fn.fnamemodify(bufname, ':e')
 
+        local win_count = config.get('show_window_count').enable and utils.get_win_count(tabpage_handle) or ''
         local padding = string.rep(' ', opt.padding)
         local left_sep = config.get('separator')
         local right_sep = index == last_index and config.get('right_separator') and left_sep or ''
@@ -35,6 +36,7 @@ local tabline = function()
             utils.get_item('TabLinePadding', padding, index),               -- Padding
             icons.get_devicon(index, bufname, extension),                   -- DevIcon
             utils.get_item('TabLine', tabname, index),                      -- Tabname (default to filename)
+            utils.get_item('TabLine', win_count, index),                    -- window count
             utils.get_item('TabLinePadding', padding, index),               -- Padding
             utils.get_item('TabLine', modified_icon, index, bufmodified),   -- Modified icon
             utils.get_item('TabLineClose', close_icon, index, bufmodified), -- Closing icon

--- a/lua/tabline/config.lua
+++ b/lua/tabline/config.lua
@@ -10,12 +10,19 @@ local default = {
     right_separator = false,
     show_index = false,
     show_icon = true,
+    show_window_count = {
+        enable = false,
+        show_if_alone = false, -- do not show count if unique win in a tab
+        count_unique_buf = true, -- count only win showing different buffers
+        count_others = true, -- display [+x] where x is the number of other windows
+        buftype_blacklist = { 'nofile' }, -- do not count if buftype among theses
+    },
 }
 
 local config = {}
 
 M.set = function(user_options)
-    config = vim.tbl_extend('force', default, user_options or {})
+    config = vim.tbl_deep_extend('force', default, user_options or {})
     return config
 end
 

--- a/lua/tabline/utils.lua
+++ b/lua/tabline/utils.lua
@@ -34,4 +34,67 @@ M.get_tabname = function(bufname, index)
     return vim.fn.fnamemodify(bufname, ':t')
 end
 
+M.is_val_in_table = function(val, tbl)
+    for _, value in pairs(tbl) do
+        if value == val then
+            return true
+        end
+    end
+    return false
+end
+
+M.is_focusable = function(win_id)
+    return vim.api.nvim_win_get_config(win_id).focusable
+end
+
+M.get_win_count = function(index)
+    local win_list = vim.api.nvim_tabpage_list_wins(index)
+
+    local buf_list = {}
+    local opts = config.get('show_window_count')
+
+    for _, win_id in pairs(win_list) do
+        if M.is_focusable(win_id) then
+            local bufnr = vim.api.nvim_win_get_buf(win_id)
+            local bt = vim.api.nvim_get_option_value('buftype', { buf = bufnr })
+
+            if not M.is_val_in_table(bt, opts.buftype_blacklist) then
+                table.insert(buf_list, bufnr)
+            end
+        end
+    end
+
+    local counted = 0
+    if opts.count_unique_buf then
+        local counted_unique = {}
+        for _, bufnr in pairs(buf_list) do
+            counted_unique[bufnr] = bufnr
+        end
+        for _, _ in pairs(counted_unique) do
+            counted = counted + 1
+        end
+    else
+        counted = #buf_list
+    end
+    if counted == 1 and not opts.show_if_alone then
+        return ''
+    else
+        if opts.count_others then
+            -- if blacklisted buftype is currently focused, the [+x] doesn't make sense, so
+            -- we kind of count it anyway
+            local focused_bt = vim.api.nvim_get_option_value(
+                'buftype',
+                { buf = vim.api.nvim_win_get_buf(vim.api.nvim_tabpage_get_win(index)) }
+            )
+            if M.is_val_in_table(focused_bt, opts.buftype_blacklist) then
+                return string.format(' [+%s]', counted)
+            else
+                return string.format(' [+%s]', counted - 1)
+            end
+        else
+            return string.format(' [%s]', counted)
+        end
+    end
+end
+
 return M

--- a/lua/tabline/utils.lua
+++ b/lua/tabline/utils.lua
@@ -34,7 +34,7 @@ M.get_tabname = function(bufname, index)
     return vim.fn.fnamemodify(bufname, ':t')
 end
 
-M.is_focusable = function(win_id)
+local is_focusable = function(win_id)
     return vim.api.nvim_win_get_config(win_id).focusable
 end
 
@@ -45,7 +45,7 @@ M.get_win_count = function(index)
     local opts = config.get('show_window_count')
 
     for _, win_id in pairs(win_list) do
-        if M.is_focusable(win_id) then
+        if is_focusable(win_id) then
             local bufnr = vim.api.nvim_win_get_buf(win_id)
             local bt = vim.api.nvim_get_option_value('buftype', { buf = bufnr })
 

--- a/lua/tabline/utils.lua
+++ b/lua/tabline/utils.lua
@@ -47,7 +47,7 @@ M.get_win_count = function(index)
     for _, win_id in pairs(win_list) do
         if is_focusable(win_id) then
             local bufnr = vim.api.nvim_win_get_buf(win_id)
-            local bt = vim.api.nvim_get_option_value('buftype', { buf = bufnr })
+            local bt = vim.bo[bufnr].buftype
 
             if not vim.list_contains(opts.buftype_blacklist, bt) then
                 table.insert(buf_list, bufnr)
@@ -73,10 +73,8 @@ M.get_win_count = function(index)
         if opts.count_others then
             -- if blacklisted buftype is currently focused, the [+x] doesn't make sense, so
             -- we kind of count it anyway
-            local focused_bt = vim.api.nvim_get_option_value(
-                'buftype',
-                { buf = vim.api.nvim_win_get_buf(vim.api.nvim_tabpage_get_win(index)) }
-            )
+            local focused_bufnr = vim.api.nvim_win_get_buf(vim.api.nvim_tabpage_get_win(index))
+            local focused_bt = vim.bo[focused_bufnr].buftype
             if vim.list_contains(opts.buftype_blacklist, focused_bt) then
                 return string.format(' [+%s]', counted)
             else

--- a/lua/tabline/utils.lua
+++ b/lua/tabline/utils.lua
@@ -34,15 +34,6 @@ M.get_tabname = function(bufname, index)
     return vim.fn.fnamemodify(bufname, ':t')
 end
 
-M.is_val_in_table = function(val, tbl)
-    for _, value in pairs(tbl) do
-        if value == val then
-            return true
-        end
-    end
-    return false
-end
-
 M.is_focusable = function(win_id)
     return vim.api.nvim_win_get_config(win_id).focusable
 end
@@ -58,7 +49,7 @@ M.get_win_count = function(index)
             local bufnr = vim.api.nvim_win_get_buf(win_id)
             local bt = vim.api.nvim_get_option_value('buftype', { buf = bufnr })
 
-            if not M.is_val_in_table(bt, opts.buftype_blacklist) then
+            if not vim.list_contains(opts.buftype_blacklist, bt) then
                 table.insert(buf_list, bufnr)
             end
         end
@@ -86,7 +77,7 @@ M.get_win_count = function(index)
                 'buftype',
                 { buf = vim.api.nvim_win_get_buf(vim.api.nvim_tabpage_get_win(index)) }
             )
-            if M.is_val_in_table(focused_bt, opts.buftype_blacklist) then
+            if vim.list_contains(opts.buftype_blacklist, focused_bt) then
                 return string.format(' [+%s]', counted)
             else
                 return string.format(' [+%s]', counted - 1)


### PR DESCRIPTION
Added option to display a windows count in the tabline. This comes with some tweaking, i.e. :
- show only when multiple windows
- count only different buffers
- show delta - displays "filename.xxx [+2]" if there is 2 other windows on top of the filename.xxx one

Image for reference : 

![image](https://github.com/user-attachments/assets/3ef05675-35c2-4cc3-b55b-cc5b3e50eb7a)

Counting only different buffers, and "other" (meaning in the current tab there is "foo.py" plus two other different files in the same tab)

![image](https://github.com/user-attachments/assets/c030dfa8-ba05-40fe-a43b-780ce444ddce)
