### PR TITLE
new feature : truncate too long lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,14 @@ require('tabline').setup({
         count_others = true,               -- display [+x] where x is the number of other windows
         buftype_blacklist = { 'nofile' },  -- do not count if buftype among theses
     },
+    -- Control the truncation algorithm.
+    -- Big numbers will tend to show more tabs agressively trucated, while small number will
+    -- tend to have less truncated tabs around active one at the cost of displaying less tabs.
+    -- Caution : the algorithm is iterative and becomes inefficient on both ends
+    -- (i.e really big or really close to 0 slopes, keep between 0.01 and 100)
+    truncation_slope = 0.8,
+    tab_on_right_icon = ' >',
+    tab_on_left_icon = '< ',
 })
 ```
 

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -2,11 +2,13 @@ local M = {}
 local icons = require('tabline.icons')
 local utils = require('tabline.utils')
 local opt
-local fix_item_len
+local fix_item_len, separator_len
+local right_ext, left_ext, right_ext_len, left_ext_len
 
--- Return one tab item, optionally truncated with max_len (in columns).
--- Minimal size depends on config and modified icon in such a way that we cannot
--- garentee the final size.
+-- Return min_size, item
+-- where min_size is the minimum size of the item
+-- (i.e. if you call with max_len < min_size, you get back an item of min_size len)
+-- and item is the item, ready to render
 local gen_item = function(index, max_len)
     local winnr = vim.fn.tabpagewinnr(index)
     local bufnr = vim.fn.tabpagebuflist(index)[winnr]
@@ -31,20 +33,20 @@ local gen_item = function(index, max_len)
     end
 
     -- Compute length and adapt if necessary
+    local icon_len = utils.eval_len(modified_icon .. close_icon)
     if max_len then
         local tabname_len = utils.eval_len(tabname)
         local win_count_len = utils.eval_len(win_count)
-        local icon_len = utils.eval_len(modified_icon .. close_icon)
         if (fix_item_len + tabname_len + win_count_len + icon_len) >= max_len then
-            if (fix_item_len + 2 + win_count_len + icon_len) >= max_len and win_count_len > 0 then
+            if win_count_len > 0 and (fix_item_len + 2 + win_count_len + icon_len) > max_len then
                 win_count = ''
                 win_count_len = 0
             end
             local trunc = max_len - fix_item_len - win_count_len - icon_len
             if trunc <= 0 then
                 tabname = '..'
-            else
-                tabname = tabname:sub(1, trunc) .. '..'
+            elseif trunc < tabname_len then
+                tabname = tabname:sub(1, trunc - 2) .. '..'
             end
         end
     end
@@ -62,32 +64,166 @@ local gen_item = function(index, max_len)
     }
     -- makes tab clickable
     local full_item = '%' .. index .. 'T' .. table.concat(tabline_items) .. '%T'
-    return full_item
+    return fix_item_len + 2 + icon_len, full_item
+end
+
+local truncated_line = function(active_idx, items, items_len, items_min_len, target, right_sep)
+    local last_index = #items
+    local target_len = {}
+
+    local trunc_slope = opt.truncation_slope
+    local start_item, end_item, idx = active_idx, active_idx, active_idx
+    local jump_size = 1
+    local jump_dir = active_idx < last_index and 1 or -1
+    local start_jump_dir = jump_dir
+    local run = 2
+
+    target_len[active_idx] = items_len[active_idx]
+    target = target - target_len[active_idx]
+    local reach_start, reach_end = false, false
+    -- Leave extra space for extension if we don't fit all tabs
+    target = target - right_ext_len - left_ext_len
+
+    -- This algo can get very inefficient with weird slopes, and I'm not 100% certain
+    -- I did not miss some edge cases. Since having your editor frozen is extremely unpleasant,
+    -- I leave this small security, breaking if it goes out of control
+    local watchdog = 1000 * vim.o.columns
+
+    while target > 0 do
+        ::continue::
+        watchdog = watchdog - 1
+        if watchdog <= 0 then
+            break
+        end
+
+        -- Jump left and right of active tab
+        idx = idx + (jump_dir * jump_size)
+        jump_size = jump_size + 1
+        jump_dir = jump_dir * -1
+        -- But reset to active a lot to favor bigger sizes around active tab
+        -- (the slope basically controls each how many jumps we start over)
+        if jump_dir ~= start_jump_dir and jump_size > run then
+            idx = active_idx
+            jump_dir = start_jump_dir
+            jump_size = 1
+            run = run + trunc_slope
+        end
+        if idx > last_index or idx < 1 then
+            goto continue
+        end
+
+        -- if new item, check that we can fit the smallest version of it
+        if target_len[idx] == nil then
+            if target > items_min_len[idx] then
+                target_len[idx] = items_min_len[idx]
+                target = target - items_min_len[idx]
+            else
+                -- No more space for new item. If all present items are fully expended, we
+                -- are stuck and abort
+                local can_expand = false
+                for i = start_item, end_item do
+                    if items_len[i] > target_len[i] then
+                        can_expand = true
+                    end
+                end
+                if can_expand then
+                    goto continue
+                else
+                    break
+                end
+            end
+        end
+        -- If we have chars left to add, we make the item bigger.
+        if items_len[idx] > target_len[idx] then
+            target_len[idx] = target_len[idx] + 1
+            target = target - 1
+        end
+
+        -- Keep track of start and end item. Adapt target if we reach the limits
+        -- since we don't need to print the arrows left or right anywore
+        start_item = math.min(start_item, idx)
+        end_item = math.max(end_item, idx)
+        if not reach_start and start_item == 1 then
+            reach_start = true
+            target = target + left_ext_len
+        end
+        if not reach_end and end_item == last_index then
+            reach_end = true
+            target = target + right_ext_len
+        end
+    end
+
+    -- Assemble final line
+    local trunc_line = ''
+    for i = 1, last_index do
+        if target_len[i] ~= nil then
+            local _, new_item = gen_item(i, target_len[i])
+            trunc_line = trunc_line .. new_item
+        end
+    end
+
+    -- If the algo failed to converge and break early, just center anyway
+    if target > 0 then
+        local r = math.floor(target / 2)
+        local l = math.ceil(target / 2)
+        trunc_line = string.rep(' ', r) .. trunc_line .. string.rep(' ', l)
+    end
+    -- Add extra tab indicators if needed
+    if reach_start and reach_end then
+        return trunc_line .. right_sep
+    elseif reach_start then
+        return trunc_line .. right_ext
+    elseif reach_end then
+        return left_ext .. trunc_line .. right_sep
+    else
+        return left_ext .. trunc_line .. right_ext
+    end
 end
 
 local tabline = function()
     local last_index = vim.fn.tabpagenr('$')
 
-    local s = ''
+    -- Generate all items, keep trace of size. Store the minimal len in case we need to truncate
+    local items = {}
+    local items_len = {}
+    local items_min_len = {}
+    local tot_len = 0
     for index = 1, last_index do
-        local item = gen_item(index)
-
-        local right_sep = index == last_index and opt.right_separator and opt.separator or ''
-        s = s .. item .. utils.get_hl('TabLineSeparator', right_sep)
+        local min_size, item = gen_item(index)
+        items[index] = item
+        local len = utils.eval_len(item)
+        items_len[index] = len
+        items_min_len[index] = min_size
+        tot_len = tot_len + len
     end
-    return s
+    local right_sep = utils.get_hl('TablineSeparator', opt.right_separator and opt.separator or '')
+    local right_sep_len = utils.eval_len(right_sep)
+    tot_len = tot_len + right_sep_len
+
+    local full_line = ''
+    if tot_len > vim.o.columns then
+        local active_idx = vim.fn.tabpagenr()
+        local target = vim.o.columns - right_sep_len
+        full_line = truncated_line(active_idx, items, items_len, items_min_len, target, right_sep)
+    else
+        full_line = table.concat(items) .. right_sep
+    end
+
+    return full_line
 end
 
 M.setup = function(user_options)
     local config = require('tabline.config')
     opt = config.set(user_options)
 
-    -- Compute fixed but config dependent size
-    local sep_len = utils.eval_len(opt.separator .. string.rep(' ', opt.padding))
-    fix_item_len = sep_len + (opt.show_icon and 2 or 0) + opt.padding
-    if opt.close_icon ~= '' then
-        fix_item_len = fix_item_len + utils.eval_len(opt.close_icon .. ' ')
-    end
+    -- Compute fixed but config dependent stuff once
+    separator_len = utils.eval_len(opt.separator .. string.rep(' ', opt.padding))
+    fix_item_len = separator_len + (opt.show_icon and 2 or 0) + opt.padding
+
+    right_ext = opt.tab_on_right_icon
+    right_ext_len = utils.eval_len(right_ext)
+    left_ext = opt.tab_on_left_icon
+    left_ext_len = utils.eval_len(left_ext)
 
     function _G.nvim_tabline()
         return tabline()

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -21,7 +21,7 @@ local tabline = function()
         local left_sep = config.get('separator')
         local right_sep = index == last_index and config.get('right_separator') and left_sep or ''
         local modified_icon = bufmodified and config.get('modified_icon') .. ' ' or ''
-        local close_icon = config.get('close_icon') .. ' '
+        local close_icon = config.get('close_icon')
 
         if opt.show_index then
             tabname = index .. ' ' .. tabname

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -15,7 +15,11 @@ local gen_item = function(index, tabpage_handle)
     local padding = string.rep(' ', opt.padding)
     local left_sep = opt.separator
     local modified_icon = bufmodified and opt.modified_icon .. ' ' or ''
-    local close_icon = opt.close_icon
+    local close_icon = not bufmodified and opt.close_icon or ''
+    if close_icon and close_icon ~= '' then
+        local hl_icon = utils.get_hl('TabLineClose', close_icon, index, bufmodified)
+        close_icon = '%' .. index .. 'X' .. hl_icon .. '%X '
+    end
 
     if opt.show_index then
         tabname = index .. ' ' .. tabname
@@ -23,14 +27,14 @@ local gen_item = function(index, tabpage_handle)
 
     -- stylua: ignore
     local tabline_items = {
-        utils.get_item('TabLineSeparator', left_sep, index),            -- Left separator
-        utils.get_item('TabLinePadding', padding, index),               -- Padding
+        utils.get_hl('TabLineSeparator', left_sep, index),            -- Left separator
+        utils.get_hl('TabLinePadding', padding, index),               -- Padding
         icons.get_devicon(index, bufname, extension),                   -- DevIcon
-        utils.get_item('TabLine', tabname, index),                      -- Tabname (default to filename)
-        utils.get_item('TabLine', win_count, index),                    -- window count
-        utils.get_item('TabLinePadding', padding, index),               -- Padding
-        utils.get_item('TabLine', modified_icon, index, bufmodified),   -- Modified icon
-        utils.get_item('TabLineClose', close_icon, index, bufmodified), -- Closing icon
+        utils.get_hl('TabLine', tabname, index),                      -- Tabname (default to filename)
+        utils.get_hl('TabLine', win_count, index),                    -- window count
+        utils.get_hl('TabLinePadding', padding, index),               -- Padding
+        utils.get_hl('TabLine', modified_icon, index, bufmodified),   -- Modified icon
+        close_icon,                                                   -- Closing icon
     }
     -- makes tab clickable
     return '%' .. index .. 'T' .. table.concat(tabline_items) .. '%T'
@@ -44,7 +48,7 @@ local tabline = function()
         local item = gen_item(index, tabpage_handle)
 
         local right_sep = index == last_index and opt.right_separator and opt.separator or ''
-        s = s .. item .. utils.get_item('TabLineSeparator', right_sep)
+        s = s .. item .. utils.get_hl('TabLineSeparator', right_sep)
     end
     return s
 end

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -1,53 +1,56 @@
 local M = {}
-local config = require('tabline.config')
+local icons = require('tabline.icons')
+local utils = require('tabline.utils')
 local opt
 
+local gen_item = function(index, tabpage_handle)
+    local winnr = vim.fn.tabpagewinnr(index)
+    local bufnr = vim.fn.tabpagebuflist(index)[winnr]
+    local bufname = vim.fn.bufname(bufnr)
+    local bufmodified = vim.fn.getbufvar(bufnr, '&mod') == 1
+    local tabname = utils.get_tabname(bufname, index)
+    local extension = vim.fn.fnamemodify(bufname, ':e')
+
+    local win_count = opt.show_window_count.enable and utils.get_win_count(tabpage_handle) or ''
+    local padding = string.rep(' ', opt.padding)
+    local left_sep = opt.separator
+    local modified_icon = bufmodified and opt.modified_icon .. ' ' or ''
+    local close_icon = opt.close_icon
+
+    if opt.show_index then
+        tabname = index .. ' ' .. tabname
+    end
+
+    -- stylua: ignore
+    local tabline_items = {
+        utils.get_item('TabLineSeparator', left_sep, index),            -- Left separator
+        utils.get_item('TabLinePadding', padding, index),               -- Padding
+        icons.get_devicon(index, bufname, extension),                   -- DevIcon
+        utils.get_item('TabLine', tabname, index),                      -- Tabname (default to filename)
+        utils.get_item('TabLine', win_count, index),                    -- window count
+        utils.get_item('TabLinePadding', padding, index),               -- Padding
+        utils.get_item('TabLine', modified_icon, index, bufmodified),   -- Modified icon
+        utils.get_item('TabLineClose', close_icon, index, bufmodified), -- Closing icon
+    }
+    -- makes tab clickable
+    return '%' .. index .. 'T' .. table.concat(tabline_items) .. '%T'
+end
+
 local tabline = function()
-    local icons = require('tabline.icons')
-    local utils = require('tabline.utils')
     local last_index = vim.fn.tabpagenr('$')
 
     local s = ''
-    for index, tabpage_handle in pairs(vim.api.nvim_list_tabpages()) do
-        local winnr = vim.fn.tabpagewinnr(index)
-        local bufnr = vim.fn.tabpagebuflist(index)[winnr]
-        local bufname = vim.fn.bufname(bufnr)
-        local bufmodified = vim.fn.getbufvar(bufnr, '&mod') == 1
-        local tabname = utils.get_tabname(bufname, index)
-        local extension = vim.fn.fnamemodify(bufname, ':e')
+    for index, tabpage_handle in ipairs(vim.api.nvim_list_tabpages()) do
+        local item = gen_item(index, tabpage_handle)
 
-        local win_count = config.get('show_window_count').enable and utils.get_win_count(tabpage_handle) or ''
-        local padding = string.rep(' ', opt.padding)
-        local left_sep = config.get('separator')
-        local right_sep = index == last_index and config.get('right_separator') and left_sep or ''
-        local modified_icon = bufmodified and config.get('modified_icon') .. ' ' or ''
-        local close_icon = config.get('close_icon')
-
-        if opt.show_index then
-            tabname = index .. ' ' .. tabname
-        end
-
-        -- Make clickable
-        s = s .. '%' .. index .. 'T'
-
-        -- stylua: ignore
-        local tabline_items = {
-            utils.get_item('TabLineSeparator', left_sep, index),            -- Left separator
-            utils.get_item('TabLinePadding', padding, index),               -- Padding
-            icons.get_devicon(index, bufname, extension),                   -- DevIcon
-            utils.get_item('TabLine', tabname, index),                      -- Tabname (default to filename)
-            utils.get_item('TabLine', win_count, index),                    -- window count
-            utils.get_item('TabLinePadding', padding, index),               -- Padding
-            utils.get_item('TabLine', modified_icon, index, bufmodified),   -- Modified icon
-            utils.get_item('TabLineClose', close_icon, index, bufmodified), -- Closing icon
-            utils.get_item('TabLineSeparator', right_sep),                  -- Right separator
-        }
-        s = s .. table.concat(tabline_items)
+        local right_sep = index == last_index and opt.right_separator and opt.separator or ''
+        s = s .. item .. utils.get_item('TabLineSeparator', right_sep)
     end
     return s
 end
 
 M.setup = function(user_options)
+    local config = require('tabline.config')
     opt = config.set(user_options)
     function _G.nvim_tabline()
         return tabline()

--- a/lua/tabline.lua
+++ b/lua/tabline.lua
@@ -3,13 +3,14 @@ local icons = require('tabline.icons')
 local utils = require('tabline.utils')
 local opt
 
-local gen_item = function(index, tabpage_handle)
+local gen_item = function(index)
     local winnr = vim.fn.tabpagewinnr(index)
     local bufnr = vim.fn.tabpagebuflist(index)[winnr]
     local bufname = vim.fn.bufname(bufnr)
     local bufmodified = vim.fn.getbufvar(bufnr, '&mod') == 1
     local tabname = utils.get_tabname(bufname, index)
     local extension = vim.fn.fnamemodify(bufname, ':e')
+    local tabpage_handle = vim.api.nvim_list_tabpages()[index]
 
     local win_count = opt.show_window_count.enable and utils.get_win_count(tabpage_handle) or ''
     local padding = string.rep(' ', opt.padding)
@@ -44,8 +45,8 @@ local tabline = function()
     local last_index = vim.fn.tabpagenr('$')
 
     local s = ''
-    for index, tabpage_handle in ipairs(vim.api.nvim_list_tabpages()) do
-        local item = gen_item(index, tabpage_handle)
+    for index = 1, last_index do
+        local item = gen_item(index)
 
         local right_sep = index == last_index and opt.right_separator and opt.separator or ''
         s = s .. item .. utils.get_hl('TabLineSeparator', right_sep)

--- a/lua/tabline/config.lua
+++ b/lua/tabline/config.lua
@@ -17,6 +17,14 @@ local default = {
         count_others = true, -- display [+x] where x is the number of other windows
         buftype_blacklist = { 'nofile' }, -- do not count if buftype among theses
     },
+    -- Control the truncation algorithm.
+    -- Big numbers will tend to show more tabs agressively trucated, while small number will
+    -- tend to have less truncated tabs around active one at the cost of displaying less tabs.
+    -- Caution : the algorithm is iterative and becomes inefficient on both ends
+    -- (i.e really big or really close to 0 slopes, keep between 0.01 and 100)
+    truncation_slope = 0.8,
+    tab_on_right_icon = ' >',
+    tab_on_left_icon = '< ',
 }
 
 local config = {}

--- a/lua/tabline/icons.lua
+++ b/lua/tabline/icons.lua
@@ -23,7 +23,7 @@ M.get_devicon = function(index, bufname, extension)
             or color
 
         vim.api.nvim_set_hl(0, icon_hl, { fg = inactive_color, bg = hl.get_bg(false) })
-        return utils.get_item(icon_hl, icon, index)
+        return utils.get_hl(icon_hl, icon, index)
     end
     return ''
 end

--- a/lua/tabline/utils.lua
+++ b/lua/tabline/utils.lua
@@ -32,6 +32,10 @@ local is_focusable = function(win_id)
     return vim.api.nvim_win_get_config(win_id).focusable
 end
 
+M.eval_len = function(str)
+    return vim.api.nvim_eval_statusline(str, { maxwidth = 1600, use_winbar = true }).width
+end
+
 M.get_win_count = function(index)
     local win_list = vim.api.nvim_tabpage_list_wins(index)
 

--- a/lua/tabline/utils.lua
+++ b/lua/tabline/utils.lua
@@ -1,7 +1,7 @@
 local M = {}
 local config = require('tabline.config')
 
-M.get_item = function(group, item, index, modified)
+M.get_hl = function(group, item, index, modified)
     if item == '' then
         return ''
     end
@@ -12,16 +12,6 @@ M.get_item = function(group, item, index, modified)
     end
     if active then
         group = group .. 'Sel'
-    end
-
-    -- Special case for close icon
-    if group:match('TabLineClose') then
-        if modified or item == '' then
-            return ''
-        end
-
-        local icon = '%#' .. group .. '#' .. item .. '%*'
-        return '%' .. index .. 'X' .. icon .. '%X '
     end
 
     return '%#' .. group .. '#' .. item .. '%*'

--- a/lua/tabline/utils.lua
+++ b/lua/tabline/utils.lua
@@ -2,6 +2,10 @@ local M = {}
 local config = require('tabline.config')
 
 M.get_item = function(group, item, index, modified)
+    if item == '' then
+        return ''
+    end
+
     local active = index == vim.fn.tabpagenr()
     if modified then
         group = group .. 'Modified'

--- a/lua/tabline/utils.lua
+++ b/lua/tabline/utils.lua
@@ -17,7 +17,7 @@ M.get_item = function(group, item, index, modified)
         end
 
         local icon = '%#' .. group .. '#' .. item .. '%*'
-        return '%' .. index .. 'X' .. icon .. '%X'
+        return '%' .. index .. 'X' .. icon .. '%X '
     end
 
     return '%#' .. group .. '#' .. item .. '%*'


### PR DESCRIPTION
Hello,
So, turns out adding a truncation mechanism was far more tricky that I anticipated. I spent quite some time trying different approaches.
My goals where : 
- The current tab is always displayed entirely
- The tabs around current should be less truncated than those far away. This gives a nice feeling when circling the tabs, of actually sliding, not just that a text line is updating.
- If we cannot show all tabs, a sign tells that there is more icon on the right/left consistently positioned (i.e. no offset by one jumps when switching tabs)

With this few commits, I consider my goals reached. The algo is a bit convoluted and "feel" quite inefficient, but the result is really nice looking, and compute time remains reasonably low. 

However, it's quite the rewrite, and nice looking is a matter of tastes. So if you don't feel this is a reasonable merge I would totally understand and be super fine with it.
If on the contrary you are happy with this stuff, well great :champagne: 

Previous behavior :  simply cut on the left by neovim. First tab hidden.
![image](https://github.com/user-attachments/assets/cb37ef4f-e84b-4329-8990-dab83dc3ff3f)

New truncation behavior : 
![tabline_trunc](https://github.com/user-attachments/assets/aab1dd8a-0fd6-42ad-948f-4538d41e061e)
